### PR TITLE
Added ColorType field to the LiveData JSON example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This data is sent out every time the score is updated, health is lost or the tim
         30,
         14
     ],
+    "ColorType": 0,
     "PlayerHealth": 100,
     "TimeElapsed": 77,
     "unixTimestamp": 1631935485375


### PR DESCRIPTION
This could be useful information for people who might want to do some cool things with it, like sync RGB lightbulbs or strips to the cube that is being hit.