### PR TITLE
Update README.md to change the example api address

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ And more!
 
 ## Dev docs (WIP):
 I've not got much here yet but to make a start I will provide some sample data that is sent out over the websocket, I may have forgotten some of the details here but this should be enough to get going for now.  
-The data is sent out as a JSON over an unsecure websocket at `ws://0.0.0.0:2946/BSDataPuller/<DATACLASS>`.  
+The data is sent out as a JSON over an unsecure websocket at `ws://127.0.0.1:2946/BSDataPuller/<DATACLASS>`.  
 I am working on getting it to be sent out over a secure websocket but unfortunatly I dont think it would be possible.  
 If you want to access this data with another mod, add DataPuller as a refrence and subscribe to the data classes `Update` events, they will pass the data as a JSON however you can read the values straight from the class if you do `<class>.<data>`.
 There are currently two data classes, they are:  


### PR DESCRIPTION
It seems like chrome (including edge and other chrome-based browsers) allows access to `ws://localhost` and `ws://127.0.0.1` in a secure context, so it's better to write these two rather than `ws://0.0.0.0`.

(verified by me and @WGzeyu)

![image](https://user-images.githubusercontent.com/66859419/186742295-406c92ad-7053-4325-bb8c-c584ec32f1dd.png)
![image](https://user-images.githubusercontent.com/66859419/186742605-7386ba2a-362e-4a6a-9804-c8972ac479da.png)


