### PR TITLE
Fix Combo, Misses, and NotesSpawned

### DIFF
--- a/src/Core/MapEvents.cs
+++ b/src/Core/MapEvents.cs
@@ -415,8 +415,16 @@ namespace DataPuller.Core
 
         private void NoteWasCutEvent(NoteController noteController, in NoteCutInfo noteCutInfo)
         {
-            if (!noteCutInfo.allIsOK) return;
             LiveData.Instance.ColorType = noteController.noteData.colorType;
+            if (!noteCutInfo.allIsOK) {
+                LiveData.Instance.FullCombo = false;
+                LiveData.Instance.Combo = 0;
+                if (noteCutInfo.noteData.colorType != ColorType.None) {
+                    LiveData.Instance.Misses++;
+                    LiveData.Instance.NotesSpawned++;
+                }
+                return;
+            }
             LiveData.Instance.NotesSpawned++;
             LiveData.Instance.Combo++;
             //Score is updated by the Harmony patch.

--- a/src/Harmony/BeatmapObjectExecutionRatingsRecorder.cs
+++ b/src/Harmony/BeatmapObjectExecutionRatingsRecorder.cs
@@ -14,7 +14,6 @@ namespace DataPuller.Harmony
             {
                 if (scoringElement is GoodCutScoringElement goodCutScoringElement)
                 {
-                    LiveData.Instance.Combo++;
                     LiveData.Instance.BlockHitScore = new()
                     {
                         PreSwing = goodCutScoringElement.cutScoreBuffer.beforeCutScore,


### PR DESCRIPTION
Fixes #26 

While testing, I noticed bad cuts weren't breaking combo, adding misses, or adding notes spawned, so fixed those. Bomb hits are not counted under misses, which is consistent with the documentation and other mods, but the LiveData.ColorType is now set correctly before returning.